### PR TITLE
Raise loss Alert only when loss is above defined limit

### DIFF
--- a/Vesper-Agents-Suite/loss-reporter/package-lock.json
+++ b/Vesper-Agents-Suite/loss-reporter/package-lock.json
@@ -13,7 +13,7 @@
         "forta-agent": "^0.0.32",
         "forta-agent-tools": "^1.0.32",
         "lru-cache": "^6.0.0",
-        "vesper-forta-module": "^1.0.9"
+        "vesper-forta-module": "^1.0.11"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
@@ -8631,9 +8631,9 @@
       }
     },
     "node_modules/vesper-forta-module": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/vesper-forta-module/-/vesper-forta-module-1.0.9.tgz",
-      "integrity": "sha512-A//ZSSG9pAxbOEhp4PHytaVGkdB/hW85E/ngCbb1UTj19mZcdn12cUUECE+7/XkRUCGQUQ8LdlaB0SYQ5hNQLA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vesper-forta-module/-/vesper-forta-module-1.0.11.tgz",
+      "integrity": "sha512-xh7NX3+n5jVYYibvtcwqDZV8oly05LVTfppTo2yllcRVbZSL4SoQE/JLofNDM0vst08K5xJSsm/+FYo3W3EaRg==",
       "dependencies": {
         "axios": "^0.26.0",
         "forta-agent": "^0.1.6",
@@ -15843,9 +15843,9 @@
       }
     },
     "vesper-forta-module": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/vesper-forta-module/-/vesper-forta-module-1.0.9.tgz",
-      "integrity": "sha512-A//ZSSG9pAxbOEhp4PHytaVGkdB/hW85E/ngCbb1UTj19mZcdn12cUUECE+7/XkRUCGQUQ8LdlaB0SYQ5hNQLA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vesper-forta-module/-/vesper-forta-module-1.0.11.tgz",
+      "integrity": "sha512-xh7NX3+n5jVYYibvtcwqDZV8oly05LVTfppTo2yllcRVbZSL4SoQE/JLofNDM0vst08K5xJSsm/+FYo3W3EaRg==",
       "requires": {
         "axios": "^0.26.0",
         "forta-agent": "^0.1.6",

--- a/Vesper-Agents-Suite/loss-reporter/package.json
+++ b/Vesper-Agents-Suite/loss-reporter/package.json
@@ -23,7 +23,7 @@
     "forta-agent": "^0.0.32",
     "forta-agent-tools": "^1.0.32",
     "lru-cache": "^6.0.0",
-    "vesper-forta-module": "^1.0.9"
+    "vesper-forta-module": "^1.0.11"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/Vesper-Agents-Suite/loss-reporter/src/abi.ts
+++ b/Vesper-Agents-Suite/loss-reporter/src/abi.ts
@@ -17,3 +17,81 @@ export const REPORT_LOSS_ABI = {
     },
   ],
 } as AbiItem;
+
+export const STRATEGY_ABI = [
+  {
+    inputs: [],
+    name: "pool",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function"
+  }
+] as AbiItem[];
+
+export const POOL_ABI = [
+  {
+    name: "decimals",
+    type: "function",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint8",
+        name: "",
+      },
+    ],
+  },
+  {
+    inputs: [],
+    name: "token",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [],
+    name: "symbol",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [],
+    name: "totalDebt",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [{internalType:"address",name:"_strategy",type:"address"}],
+    name: "totalDebtOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function"
+  },
+] as AbiItem[];
+
+
+export const ROUTER_ABI = [
+  {
+    name: "getAmountsOut",
+    type: "function",
+    inputs: [{
+      internalType: "uint256",
+      name: "amountIn",
+      type: "uint256"
+    },
+    {
+      internalType: "address[]",
+      name: "path",
+      type: "address[]"
+    },
+    ],
+    outputs: [
+      {
+        internalType: "uint256[]",
+        type: "uint256[]",
+        name: "amounts",
+      },
+    ],
+  }
+] as AbiItem[];

--- a/Vesper-Agents-Suite/loss-reporter/src/agent.ts
+++ b/Vesper-Agents-Suite/loss-reporter/src/agent.ts
@@ -14,10 +14,26 @@ import {
   hasLosses,
 } from "./utils";
 import { VesperFetcher } from 'vesper-forta-module';
+import BigNumber from "bignumber.js";
 import Web3 from "web3";
 const web3: Web3 = new Web3(getJsonRpcUrl());
 const vesperFetcher: VesperFetcher = new VesperFetcher(web3);
-import { REPORT_LOSS_ABI, earningReportedSignature } from "./abi";
+import { REPORT_LOSS_ABI, STRATEGY_ABI, POOL_ABI, ROUTER_ABI, earningReportedSignature } from "./abi";
+const REPORT_LOSS_LIMIT = 50 // Report loss above 50 USD
+
+async function getContracts() {
+  const network = await vesperFetcher.getNetworkName()
+  // mainnet
+  let nativeToken = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+  let router = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+  let usdc = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+  if (network === 'Avalanche') {
+    nativeToken = '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7'
+    router = '0x60aE616a2155Ee3d9A68541Ba4544862310933d4'
+    usdc = '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'
+  }
+  return { nativeToken, router, usdc }
+}
 
 export const provideHandleTransaction = (web3: Web3): HandleTransaction => {
   return async (txEvent: TransactionEvent): Promise<Finding[]> => {
@@ -61,10 +77,31 @@ export const provideHandleTransaction = (web3: Web3): HandleTransaction => {
 
     let findingsWithMetadata: Finding[] = [];
     for (let finding of findings) {
-      const metadataInfo = await vesperFetcher.getMetaData(finding.metadata.strategyAddress, txEvent.blockNumber)
-      const description = finding.description + metadataInfo + ", lossValue = " + finding.metadata.lossValue;
-      const findingWithMetadata = { ...finding, description: description }
-      findingsWithMetadata = findingsWithMetadata.concat(Finding.fromObject(findingWithMetadata));
+      const metadata = await vesperFetcher.getMetaData(finding.metadata.strategyAddress, txEvent.blockNumber)
+      const strategyContract = new web3.eth.Contract(STRATEGY_ABI, finding.metadata.strategyAddress);
+      const poolAddress = await strategyContract.methods.pool().call({});
+      const poolContract = new web3.eth.Contract(POOL_ABI, poolAddress);
+      const collateralToken = await poolContract.methods.token().call({});
+      const strategyDebt = await poolContract.methods.totalDebtOf(finding.metadata.strategyAddress).call({}, txEvent.blockNumber);
+      const strategyLossInTvl = strategyDebt > 0 ? new BigNumber(finding.metadata.lossValue).multipliedBy(100).dividedBy(strategyDebt) : 0
+      const collateralContract = new web3.eth.Contract(POOL_ABI, collateralToken);
+      const decimals = await collateralContract.methods.decimals().call({});
+      const symbol = await collateralContract.methods.symbol().call({});
+
+      const lossInCollateral = new BigNumber(finding.metadata.lossValue).dividedBy(new BigNumber('1e' + decimals.toString()))
+      const { nativeToken, router, usdc } = await getContracts()
+      const routerContract = new web3.eth.Contract(ROUTER_ABI, router);
+      const path = web3.utils.toChecksumAddress(collateralToken) === web3.utils.toChecksumAddress(nativeToken)
+        ? [collateralToken, usdc]
+        : [collateralToken, nativeToken, usdc]
+      const amountsOut = await routerContract.methods.getAmountsOut(finding.metadata.lossValue, path).call({})
+      const lossInUSDC = amountsOut[path.length - 1]
+      const lossInUSD = new BigNumber(lossInUSDC).dividedBy(new BigNumber('1e6'))
+      if (lossInUSD.gt(REPORT_LOSS_LIMIT)) { // raise alert only when loss > REPORT_LOSS_ABOVE USD
+        const description = `${finding.description} ${metadata.strategyName} of ${metadata.poolName}.\n lossInCollateral = ${lossInCollateral} ${symbol}\n lossInUSD = $${lossInUSD.toFixed(2)}\n lossOfStrategyTVL = ${strategyLossInTvl.toFixed(2)}%\n strategyAddress = ${metadata.strategyAddress}\n poolAddress = ${metadata.poolAddress}\n network = ${metadata.network}`
+        const findingWithMetadata = { ...finding, description }
+        findingsWithMetadata = findingsWithMetadata.concat(Finding.fromObject(findingWithMetadata));
+      }
     }
     return findingsWithMetadata;
   };

--- a/Vesper-Agents-Suite/loss-reporter/src/utils.ts
+++ b/Vesper-Agents-Suite/loss-reporter/src/utils.ts
@@ -5,31 +5,10 @@ import {
   decodeParameter,
 } from "forta-agent-tools";
 
-export const createFindingCallDetector: FindingGenerator = (callInfo) => {
-  return Finding.fromObject({
+function prepareFindingObject(strategyAddress:string, lossValue:any){
+  return {
     name: "Loss Reported",
-    description:
-      "A loss was reported by strategy.",
-    alertId: "Vesper",
-    type: FindingType.Info,
-    severity: FindingSeverity.Info,
-    protocol: "Vesper",
-    metadata: {
-      strategyAddress: callInfo?.arguments[0],
-      lossValue: callInfo?.arguments[1],
-    },
-  });
-};
-
-export const createFindingEventDetector: FindingGenerator = (eventInfo) => {
-  const { 1: lossValue } = decodeParameters(
-    ["uint256", "uint256", "uint256", "uint256", "uint256", "uint256"],
-    eventInfo?.data
-  );
-  const strategyAddress: string = decodeParameter("address", eventInfo?.topics[1]);
-  return Finding.fromObject({
-    name: "Loss Reported",
-    description: "A loss was reported by strategy.",
+    description: "Loss reported by",
     alertId: "Vesper",
     type: FindingType.Info,
     severity: FindingSeverity.Info,
@@ -38,7 +17,20 @@ export const createFindingEventDetector: FindingGenerator = (eventInfo) => {
       strategyAddress,
       lossValue,
     },
-  });
+  }
+}
+
+export const createFindingCallDetector: FindingGenerator = (callInfo) => {
+  return Finding.fromObject(prepareFindingObject(callInfo?.arguments[0], callInfo?.arguments[1]));
+};
+
+export const createFindingEventDetector: FindingGenerator = (eventInfo) => {
+  const { 1: lossValue } = decodeParameters(
+    ["uint256", "uint256", "uint256", "uint256", "uint256", "uint256"],
+    eventInfo?.data
+  );
+  const strategyAddress: string = decodeParameter("address", eventInfo?.topics[1]);
+  return Finding.fromObject(prepareFindingObject(strategyAddress, lossValue));
 };
 
 export const hasLosses = (log: Log) => {

--- a/Vesper-Agents-Suite/vesper-forta-module/package.json
+++ b/Vesper-Agents-Suite/vesper-forta-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-forta-module",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Common function required by Vesper to run Forta bots",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/Vesper-Agents-Suite/vesper-forta-module/src/vesper.fetcher.ts
+++ b/Vesper-Agents-Suite/vesper-forta-module/src/vesper.fetcher.ts
@@ -157,9 +157,14 @@ export default class VesperFetcher {
     );
    
     return Promise.all([this.getNetworkName(), strategyContract.methods.NAME().call({}, block), poolContract.methods.name().call({}, block)])
-      .then(function ([networkName, strategyName, poolName]) {
-        const metadataInfo = ` network = ${networkName}, strategyName = ${strategyName}, strategyAddress = ${strategyAddress}, poolName = ${poolName}, poolAddress = ${poolAddress}`
-        return metadataInfo
+      .then(function ([network, strategyName, poolName]) {
+        return {
+          network,
+          strategyName,
+          strategyAddress,
+          poolName,
+          poolAddress
+        }        
       })
   }
 


### PR DESCRIPTION
- Raise loss Alert only when the loss is above the defined limit (50 USD)
- Mention loss in Collateral Token, Strategy Total value and in USD.
- Mention loss in decimals to make it more readable.

closes https://github.com/bloqpriv/vesper-contracts/issues/41
The alert is working fine. Live example : https://bloqinc.slack.com/archives/C02RJLCMUM8/p1657783815167189

Alert  Test example.

```
Loss reported by ConvexD3PoolStrategyFEI of vaFEI Pool. lossInCollateral = 564.844038249859661408 FEI, lossInUSD = $495.87, lossOfStrategyTVL = 5.96%, strategyAddress = 0x2E746ADfdA5fCBb3E145Af4415632630Abd199D6, poolAddress = 0x2B6c40Ef15Db0D78D08A7D1b4E12d57E88a3e324, network = Ethereum
```
