### PR TITLE
Fix XY stratety unhealthy borrow and duplicate txn

### DIFF
--- a/Vesper-Agents-Suite/loss-reporter/src/agent.ts
+++ b/Vesper-Agents-Suite/loss-reporter/src/agent.ts
@@ -98,7 +98,9 @@ export const provideHandleTransaction = (web3: Web3): HandleTransaction => {
       const lossInUSDC = amountsOut[path.length - 1]
       const lossInUSD = new BigNumber(lossInUSDC).dividedBy(new BigNumber('1e6'))
       if (lossInUSD.gt(REPORT_LOSS_LIMIT)) { // raise alert only when loss > REPORT_LOSS_ABOVE USD
-        const description = `${finding.description} ${metadata.strategyName} of ${metadata.poolName}.\n lossInCollateral = ${lossInCollateral} ${symbol}\n lossInUSD = $${lossInUSD.toFixed(2)}\n lossOfStrategyTVL = ${strategyLossInTvl.toFixed(2)}%\n strategyAddress = ${metadata.strategyAddress}\n poolAddress = ${metadata.poolAddress}\n network = ${metadata.network}`
+        const description = `${finding.description} ${metadata.strategyName} of ${metadata.poolName}.\n lossInCollateral = ${lossInCollateral} ${symbol}\n 
+        lossInUSD = $${lossInUSD.toFixed(0)}\n lossOfStrategyTVL = ${strategyLossInTvl.toFixed(2)}%\n strategyAddress = ${metadata.strategyAddress}\n 
+        poolAddress = ${metadata.poolAddress}\n network = ${metadata.network}`
         const findingWithMetadata = { ...finding, description }
         findingsWithMetadata = findingsWithMetadata.concat(Finding.fromObject(findingWithMetadata));
       }

--- a/Vesper-Agents-Suite/unhealthy-borrow-reporter/src/agent.ts
+++ b/Vesper-Agents-Suite/unhealthy-borrow-reporter/src/agent.ts
@@ -12,9 +12,9 @@ import {
 import { createFinding, contains } from "./utils";
 import BigNumber from "bignumber.js";
 const STRATEGY_KEY = "_Strategies"
-const COMPOUND_STRATEGIES = ["BenqiXYStrategy", "TraderJoeXYStrategy", "CompoundXYStrategy", "IronBankXYStrategy"]
-const AAVE_STRATEGIES = ["AaveXYStrategy"]
-const MAKER_STRATEGIES = ["MakerStrategy", "Maker-Strategy"]
+const COMPOUND_STRATEGIES = ["BenqiXY", "TraderJoeXY", "CompoundXY", "IronBankXY", "Compound_Vesper_Xy", "TraderJoe_Vesper_Xy", "Benqi_Vesper_Xy"]
+const AAVE_STRATEGIES = ["AaveXY", "AaveV2_Vesper_Xy", "Aave_Vesper_Xy"]
+const MAKER_STRATEGIES = ["Maker"]
 const TRADER_JOE = 'TraderJoe'
 const web3: Web3 = new Web3(getJsonRpcUrl());
 const cache: LRU<string, string[]> = new LRU<string, string[]>({ max: 100 });

--- a/Vesper-Agents-Suite/unhealthy-borrow-reporter/src/utils.ts
+++ b/Vesper-Agents-Suite/unhealthy-borrow-reporter/src/utils.ts
@@ -15,13 +15,13 @@ export const createFinding = (metadata: any): Finding => {
 
 const objToString = (obj: any): string => {
   return Object.entries(obj).reduce((str, [p, val]) => {
-    return `${str}${p}: ${val}, `;
+    return `${str}${p}: ${val}\n `;
   }, '');
 }
 
 export const contains = (array: string[], name: string): any => {
   return array.some(element => {
-    if (name.includes(element)) {
+    if (name.toLowerCase().includes(element.toLowerCase())) {
       return true;
     }
     return false;


### PR DESCRIPTION
- Fixed XY strategy unhealthy borrow case. This is needed due to a change in naming.
- Formated message for unhealthy borrow case
- Avoid submitting duplicate alerts. The duplicate alert is due to minor changes in value (in decimal) for loss-reported agent. Forta agents are running on multiple nodes. They will raise consider it a different alert if hashing of the delivered message is different. In some cases, the generated hash is different due to a minor difference in decimal values for the `lossInUSD` field. An example we have got 3 alerts for same txn where lossInUSD = $127.03, lossInUSD = $127.04 and lossInUSD = $127.06 (all at same block number).

closes https://github.com/bloqpriv/vesper-pools/issues/1430
